### PR TITLE
Update gameData.js

### DIFF
--- a/src/lib/gameData.js
+++ b/src/lib/gameData.js
@@ -135,7 +135,7 @@ export const silkSkillsList = [
     { name: "Cross Stitch", location: "478371", flag: "hasParry" },
     { name: "Sharpdart", location: "479079", flag: "hasHarpoonDash" },
     { name: "Rune Rage", location: "479025", flag: "hasSilkBomb" },
-    { name: "Pale Nails", location: "479606", flag: "hasSilkCharge" },
+    { name: "Pale Nails", location: "479606", flag: "hasSilkBossNeedle" },
 ];
 
 export const ToolList = [


### PR DESCRIPTION
Fixes the flag for the "Pale Nails" Silk Skill

The "hasSilkCharge" flag for the "Pale Nails" skill is most definitely incorrect. I have verified this with one of my ACT II saves that doesn't have this skill.

"hasSilkCharge" most probably has to do with silk regeneration that happens once you get a Silk Heart; however, this has to be verified.